### PR TITLE
TC-33: Implemented the project update job

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Tower companion provides the following command line scripts:
 -  [kick_and_monitor](#kick_and_monitor)
 -  [ad_hoc](#ad_hoc)
 -  [ad_hoc_and_monitor](#ad_hoc_and_monitor)
+-  [update_project](#update_project)
 
 
 Requirements
@@ -352,6 +353,7 @@ example:
     you can download the full output from:
     https://<ansible tower instance>/api/v1/jobs/20895/stdout/?format=txt_download
 
+
 ### <a name="update_project"></a>
 update_project
 ----
@@ -379,5 +381,5 @@ usage:
 
 example:
 
-    $ update_project --project-name avaya_web
+    $ update_project --project-name jboss
     Started job: 12345

--- a/README.md
+++ b/README.md
@@ -351,3 +351,33 @@ example:
 
     you can download the full output from:
     https://<ansible tower instance>/api/v1/jobs/20895/stdout/?format=txt_download
+
+### <a name="update_project"></a>
+update_project
+----
+This script updates a project (SCM Update).
+
+Params:
+
+-  project-name: Ansible tower project name
+
+Returns:
+
+-  exit code 0 if the project update has been started successfully
+-  exit code 1 if any issues
+
+usage:
+
+    update_project --help
+    Usage: update_project [OPTIONS]
+
+      Update a project from the command line
+
+    Options:
+      --project-name TEXT  Project name  [required]
+      --help               Show this message and exit.
+
+example:
+
+    $ update_project --project-name avaya_web
+    Started job: 12345

--- a/lib/adhoc.py
+++ b/lib/adhoc.py
@@ -17,6 +17,8 @@ class AdHoc(object):
     """
     AdHoc job
     """
+    JOB_TYPE = 'run'
+    JOB_EXPLANATION = 'Ad Hoc job run by tower-companion'
     # pylint: disable=too-many-instance-attributes
     # those are the parameters we need to send to the api to kick off an ad hoc
     # job.
@@ -27,8 +29,8 @@ class AdHoc(object):
         self.module_args = None
         self.become = None
         self.limit = None
-        self.job_type = None
-        self.job_explanation = None
+        self.job_type = self.JOB_TYPE
+        self.job_explanation = self.JOB_EXPLANATION
 
     def is_valid(self):
         """

--- a/lib/api.py
+++ b/lib/api.py
@@ -178,7 +178,7 @@ class APIv1(object):
         Returns a json object with data about name
 
         Args:
-            name (str): name of the template
+            name (str): name of the project
 
         Returns:
             (json object)

--- a/lib/api.py
+++ b/lib/api.py
@@ -81,7 +81,8 @@ class APIv1(object):
         headers = {'Content-type': 'application/json'}
         request = requests.post(url, auth=auth, verify=verify, params=params,
                                 data=json.dumps(data), headers=headers)
-        if request.status_code in (requests.codes.ok, requests.codes.created):
+        if request.status_code in (requests.codes.ok, requests.codes.created,
+                                   requests.codes.accepted):
             return request
         else:
             msg = "Failed to post {0} - {1}".format(url, request.reason)
@@ -172,20 +173,20 @@ class APIv1(object):
         """
         return self._get_data(name=name, endpoint='job_templates')
 
-    def template_id(self, name):
+    def project_data(self, name):
         """
-        Returns a template id from a name
+        Returns a json object with data about name
 
         Args:
             name (str): name of the template
 
         Returns:
-            (str): id of the template name
+            (json object)
 
         Raises:
             APIError
         """
-        return self._get_id(name=name, endpoint='job_templates')
+        return self._get_data(name=name, endpoint='projects')
 
     def launch_template_id(self, template_id, extra_vars):
         """
@@ -205,6 +206,24 @@ class APIv1(object):
                                                      template_id)
         extra_vars = {'extra_vars': extra_vars}
         request = self._post(url, params={}, data=extra_vars)
+        return json.loads(request.text)
+
+    def update_project_id(self, project_id):
+        """
+        Updates project
+
+        Params:
+            project_id (str): project_id
+
+        Returns:
+            (str): id of the started job
+
+        Raises:
+            APIError
+        """
+        url = "{0}/projects/{1}/update/".format(self.api_url,
+                                                     project_id)
+        request = self._post(url, params={}, data={})
         return json.loads(request.text)
 
     def adhoc_to_api(self, adhoc):

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -100,6 +100,25 @@ def cli_kick(template_name, extra_vars):
         print(msg)
         sys.exit(1)
 
+@click.command()
+@click.option('--project-name', help='Project name', required=True)
+def cli_update_project(project_name):
+    """
+    Update a project from the command line
+    """
+    try:
+        # verify configuration
+        config = Config(config_file())
+        guard = Guard(config)
+        project_id = guard.get_project_id(project_name)
+        guard.update_project(project_id=project_id)
+        print('Started updating project: {0}'.format(project_name))
+    except GuardError as error:
+        msg = 'Error updating project: {0} - {1}'.format(project_name,
+                                                            error)
+        print(msg)
+        sys.exit(1)
+
 
 @click.command()
 @click.option('--job-id', help='Job id to monitor', required=True)

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -179,19 +179,16 @@ def cli_kick_and_monitor(template_name, extra_vars, output_format):
 @click.option('--machine-credential', help='SSH credentials name',
               required=True)
 @click.option('--module-name', help='Ansible module to run', required=True)
-@click.option('--job-type', type=click.Choice(['run', 'check']),
-              help='Type of job so execute', default='run')
 @click.option('--module-args', help='Arguments for the selected module',
               type=str, default='')
 @click.option('--limit', help='Limit to hosts', type=str, default='')
-@click.option('--job-explanation', help='Job description', type=str, default='')
 @click.option('--become', help='Become root', is_flag=True)
 @click.option('--output-format',
               type=click.Choice(['ansi', 'txt']),
               default='ansi',
               help='output format')
 def cli_ad_hoc_and_monitor(inventory, machine_credential, module_name,
-                           module_args, job_type, limit, job_explanation,
+                           module_args, limit,
                            become, output_format):
     """
     Trigger an ansible tower ad hoc job and monitor its execution.
@@ -203,13 +200,8 @@ def cli_ad_hoc_and_monitor(inventory, machine_credential, module_name,
         adhoc.credential_id = machine_credential
         adhoc.module_name = module_name
         adhoc.module_args = module_args
-        adhoc.job_type = job_type
         adhoc.limit = limit
-        adhoc.job_explanation = job_explanation
         adhoc.become = become
-        # extra vars are not passed from the command line, extend this in a
-        # future version
-        adhoc.extra_vars = []
         config = Config(config_file())
         guard = Guard(config)
         guard.ad_hoc_and_monitor(adhoc, output_format=output_format,
@@ -223,15 +215,11 @@ def cli_ad_hoc_and_monitor(inventory, machine_credential, module_name,
 @click.option('--inventory', help='Inventory to run on', required=True)
 @click.option('--machine-credential', help='SSH credentials name', required=True)
 @click.option('--module-name', help='Ansible module to run', required=True)
-@click.option('--job-type', type=click.Choice(['run', 'check']),
-              help='Type of job so execute', default='run')
 @click.option('--module-args', help='Arguments for the selected module', type=str, default='')
 @click.option('--limit', help='Limit to hosts', type=str, default='')
-@click.option('--job-explanation', help='Job description', type=str, default='')
-@click.option('--verbose', help='Verbose mode', is_flag=True)
 @click.option('--become', help='Become root', is_flag=True)
-def cli_ad_hoc(inventory, machine_credential, module_name, job_type,
-               module_args, limit, job_explanation, verbose, become):
+def cli_ad_hoc(inventory, machine_credential, module_name,
+               module_args, limit, become):
     """
     Trigger an ansible tower ad hoc job and monitor its execution.
     In case of error it returns a bad exit code.
@@ -242,13 +230,8 @@ def cli_ad_hoc(inventory, machine_credential, module_name, job_type,
         adhoc.credential_id = machine_credential
         adhoc.module_name = module_name
         adhoc.module_args = module_args
-        adhoc.job_type = job_type
         adhoc.limit = limit
-        adhoc.job_explanation = job_explanation
         adhoc.become = become
-        # extra vars are not passed from the command line, extend this in a
-        # future version
-        adhoc.extra_vars = []
         config = Config(config_file())
         guard = Guard(config)
         result = guard.ad_hoc(adhoc)

--- a/lib/tc.py
+++ b/lib/tc.py
@@ -50,6 +50,40 @@ class Guard(object):
         except APIError as error:
             raise GuardError(error)
 
+    def get_project_id(self, project_name):
+        """
+        Returns a project id from a project name
+        Args:
+            project_name (str): the name of project
+
+        Retruns:
+            (str): project id if found
+
+        Raises:
+            GuardError
+        """
+        api = self.api
+        try:
+            data = api.project_data(project_name)
+            return data['results'][0]['id']
+        except APIError as error:
+            raise GuardError(error)
+
+    def update_project(self, project_id):
+        """
+        Updateds a project in ansible tower
+        Args:
+            project_id (int): id of the project to update
+        Returns:
+            job_id (int): id of the triggered job
+        Raises:
+            GuardError
+        """
+        try:
+            return self.api.update_project_id(project_id)
+        except APIError as error:
+            raise GuardError(error)
+
     def kick(self, template_id, extra_vars):
         """
         Starts a job in ansible tower
@@ -137,9 +171,8 @@ class Guard(object):
         Raises:
             GuardError
         """
-        api = self.api
         try:
-            template_id = api.template_id(template_name)
+            template_id = self.get_template_id(template_name)
             job = self.kick(template_id, extra_vars)
             job_url = self.launch_data_to_url(job)
             self.monitor(job_url, output_format, sleep_interval)

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ setup(
             'kick=lib.cli:cli_kick',
             'ad_hoc_and_monitor=lib.cli:cli_ad_hoc_and_monitor',
             'ad_hoc=lib.cli:cli_ad_hoc',
+            'update_project=lib.cli:cli_update_project'
         ],
     },
     tests_require=['tox'],

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -182,7 +182,6 @@ def test_get_ids(monkeypatch):
 
     monkeypatch.setattr('requests.get', mockreturn)
     api = basic_api()
-    assert api.template_id(name='') == expected_id
     assert api.inventory_id(name='') == expected_id
     assert api.credential_id(name='') == expected_id
 
@@ -201,9 +200,6 @@ def test_get_ids_zero_results(monkeypatch):
             return mock
 
         monkeypatch.setattr('requests.get', mockreturn)
-        with pytest.raises(APIError):
-            api.template_id(name='')
-
         with pytest.raises(APIError):
             api.inventory_id(name='')
 
@@ -237,6 +233,29 @@ def test_launch_template_id(monkeypatch):
     with pytest.raises(APIError):
         api.launch_template_id(template_id='', extra_vars='')
 
+
+def test_update_project_id(monkeypatch):
+    expected_id = 123
+    fake_text = json.dumps({'results': [{'id': expected_id}]})
+
+    def mockreturn(*args, **kwargs):
+        mock = MockRequest()
+        mock.text = fake_text
+        mock.status_code = 200
+        return mock
+
+    def mockerror(*args, **kwargs):
+        raise APIError
+
+    api = basic_api()
+    monkeypatch.setattr('requests.post', mockreturn)
+    api = basic_api()
+    result = api.update_project_id(project_id='')
+    assert result == json.loads(fake_text)
+
+    monkeypatch.setattr('requests.post', mockerror)
+    with pytest.raises(APIError):
+        api.update_project_id(project_id='')
 
 def test_launch_data_to_url():
     api = basic_api()
@@ -336,6 +355,7 @@ def test_get_data(monkeypatch):
 
     monkeypatch.setattr('requests.get', mockreturn)
     assert api.template_data(name='') == json.loads(fake_text)
+    assert api.project_data(name='') == json.loads(fake_text)
     assert api.inventory_data(name='') == json.loads(fake_text)
     assert api.credentials_data(name='') == json.loads(fake_text)
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -7,6 +7,7 @@ from click.testing import CliRunner
 from lib.tc import GuardError
 from lib.cli import cli_kick, cli_monitor, DEFAULT_CONFIGURATION, config_file
 from lib.cli import cli_kick_and_monitor, cli_ad_hoc_and_monitor, cli_ad_hoc
+from lib.cli import cli_update_project
 from lib.cli import extra_var_to_dict, CLIError
 
 
@@ -82,6 +83,31 @@ def test_cli_kick(monkeypatch):
                                       '--extra-vars', 'version: 1.0'])
     assert result.exit_code == 1
 
+def test_cli_update_project(monkeypatch):
+
+    def mockerror(*args, **kwargs):
+        raise GuardError
+
+    def mock_cli_error(*args, **kwargs):
+        raise CLIError
+
+    def mockreturn(*args, **kwargs):
+        return 'just a test'
+
+    monkeypatch.setattr('lib.tc.Guard.get_project_id', mockreturn)
+    monkeypatch.setattr('lib.tc.Guard.update_project', mockreturn)
+    monkeypatch.setattr('lib.tc.Guard.launch_data_to_url', mockreturn)
+    monkeypatch.setattr('lib.cli.config_file', mock_config_file)
+
+    runner = CliRunner()
+    # clean execution
+    result = runner.invoke(cli_update_project, ['--project-name', 'test'])
+    assert result.exit_code == 0
+
+    # whooops! error
+    monkeypatch.setattr('lib.tc.Guard.get_project_id', mockerror)
+    result = runner.invoke(cli_update_project, ['--project-name', 'test'])
+    assert result.exit_code == 1
 
 def test_cli_monitor(monkeypatch):
 

--- a/test/test_guard.py
+++ b/test/test_guard.py
@@ -290,7 +290,6 @@ def test_ad_hoc_and_monitor(monkeypatch):
 
     guard = basic_guard()
     ad_hoc = AdHoc()
-    ad_hoc.extra_vars = []
     guard.ad_hoc_and_monitor(ad_hoc, output_format='any', sleep_interval=0.0)
 
     monkeypatch.setattr('lib.tc.Guard.ad_hoc', mock_guard_error)

--- a/test/test_guard.py
+++ b/test/test_guard.py
@@ -50,6 +50,9 @@ class ApiMock(object):
     def get_template_id(self):
         return json.load(BASIC_JSON_DATA)
 
+    def get_project_id(self):
+        return json.load(BASIC_JSON_DATA)
+
 
 class MockRequest(object):
     def __init__(self, *args, **kwargs):
@@ -83,6 +86,22 @@ def test_get_template_id(monkeypatch):
     with pytest.raises(GuardError):
         guard.get_template_id(template_name='')
 
+def test_get_project_id(monkeypatch):
+    guard = basic_guard()
+
+    expected_id = '1'
+    fake_result = {'results': [{'id': expected_id}]}
+    def mockreturn(self, project_name):
+        return fake_result
+    monkeypatch.setattr('lib.api.APIv1.project_data', mockreturn)
+    assert guard.get_project_id('') == expected_id
+
+    def mockreturn(self, project_name):
+        raise APIError
+
+    monkeypatch.setattr('lib.api.APIv1.project_data', mockreturn)
+    with pytest.raises(GuardError):
+        guard.get_project_id(project_name='')
 
 def test_kick(monkeypatch):
     # quite a lot of changes, this test has to be updated
@@ -102,6 +121,23 @@ def test_kick(monkeypatch):
     with pytest.raises(GuardError):
         guard.kick(template_id='', extra_vars='')
 
+def test_update_project(monkeypatch):
+    # quite a lot of changes, this test has to be updated
+    guard = basic_guard()
+    expected_value = 'update'
+
+    def mockreturn(*args, **kwargs):
+        expected_value
+
+    monkeypatch.setattr('lib.api.APIv1.update_project_id', mockreturn)
+    guard.update_project(project_id='')
+
+    def mockreturn(*args, **kwargs):
+        raise APIError
+
+    monkeypatch.setattr('lib.api.APIv1.update_project_id', mockreturn)
+    with pytest.raises(GuardError):
+        guard.update_project(project_id='')
 
 def test_download_url():
     guard = basic_guard()
@@ -173,13 +209,13 @@ def test_kick_and_monitor(monkeypatch):
 
     monkeypatch.setattr('lib.tc.Guard.kick', mockreturn)
     monkeypatch.setattr('lib.tc.Guard.monitor', mockreturn)
-    monkeypatch.setattr('lib.api.APIv1.template_id', mockreturn)
+    monkeypatch.setattr('lib.tc.Guard.get_template_id', mockreturn)
     monkeypatch.setattr('lib.api.APIv1.launch_data_to_url', mockreturn)
 
     guard.kick_and_monitor(template_name='', extra_vars=[], output_format='',
                            sleep_interval=0.0)
 
-    monkeypatch.setattr('lib.api.APIv1.template_id', mockerror)
+    monkeypatch.setattr('lib.tc.Guard.get_template_id', mockerror)
     with pytest.raises(GuardError):
         guard.kick_and_monitor(template_name='', extra_vars=[],
                                output_format='', sleep_interval=0.0)


### PR DESCRIPTION
Closes #33 

```
update_project --help
Usage: update_project [OPTIONS]

  Update a project from the command line

Options:
  --project-name TEXT  Project name  [required]
  --help               Show this message and exit.
```
