### PR TITLE
TC-36: Set user permissions for a template

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,3 +351,42 @@ example:
 
     you can download the full output from:
     https://<ansible tower instance>/api/v1/jobs/20895/stdout/?format=txt_download
+
+
+### <a name="template_permissions"></a>
+template_permissions
+----------------
+You use this template_permissions functionality, if you want to grand
+permissions to a user for a specific job-template
+
+Params:
+
+-  username: Ansible tower user name
+-  template-name: Ansible tower template name
+
+Returns:
+
+-  exit code 0 if the job completed without errors
+-  exit code 1 if any issues
+
+usage:
+
+
+    Usage: template_permissions [OPTIONS]
+
+      This sets the template permissions for a user
+
+    Options:
+      --username TEXT                 User to grant permissions  [required]
+      --template-name TEXT            Template to grant permissions for
+                                      [required]
+      --permission [read|execute|admin]
+                                      Type of permission
+      --help                          Show this message and exit.
+
+example:
+
+    $ template_permissions --username Wilhelm \
+                           --template-name "Bierbrauer" \
+                           --permission admin
+    User Wilhelm successfully granted admin permissions for template Bierbrauer

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Tower companion provides the following command line scripts:
 -  [kick_and_monitor](#kick_and_monitor)
 -  [ad_hoc](#ad_hoc)
 -  [ad_hoc_and_monitor](#ad_hoc_and_monitor)
+-  [template_permissions](#template_permissions)
 
 
 Requirements

--- a/lib/api.py
+++ b/lib/api.py
@@ -21,6 +21,7 @@ class APIv1(object):
     """
     APIv1
     """
+    LONG_PAGING = 10000
     # pylint: disable=E1101
     # disables:
     # E: Instance of 'LookupDict' has no 'ok' member (no-member)
@@ -202,7 +203,7 @@ class APIv1(object):
         Raises:
             APIError
         """
-        params = {'page_size': '10000'}
+        params = {'page_size': self.LONG_PAGING}
         return self._get_data(endpoint='roles', params=params)
 
     def user_data(self, username):

--- a/lib/api.py
+++ b/lib/api.py
@@ -237,7 +237,7 @@ class APIv1(object):
         Raises:
             APIError
         """
-        return self._get_data(name=name, endpoint='projects')
+        return self._get_data_by_name(name=name, endpoint='projects')
 
     def launch_template_id(self, template_id, extra_vars):
         """

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -242,7 +242,7 @@ def cli_ad_hoc(inventory, machine_credential, module_name, job_type,
 @click.option('--username', help='User to grant permissions', required=True)
 @click.option('--template-name', help='Template to grant permissions for',
               required=True)
-@click.option('--permission', type=click.Choice(['Read', 'Execute', 'Admin']),
+@click.option('--permission', type=click.Choice(['read', 'execute', 'admin']),
               help='Type of permission', default='read')
 def cli_template_permissions(username, template_name, permission):
     """

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -242,7 +242,7 @@ def cli_ad_hoc(inventory, machine_credential, module_name, job_type,
 @click.option('--username', help='User to grant permissions', required=True)
 @click.option('--template-name', help='Template to grant permissions for',
               required=True)
-@click.option('--permission', type=click.Choice(['read', 'execute', 'admin']),
+@click.option('--permission', type=click.Choice(['Read', 'Execute', 'Admin']),
               help='Type of permission', default='read')
 def cli_template_permissions(username, template_name, permission):
     """

--- a/lib/cli.py
+++ b/lib/cli.py
@@ -237,3 +237,24 @@ def cli_ad_hoc(inventory, machine_credential, module_name, job_type,
     except GuardError as error:
         print("Execution Error: {0}".format(error))
         sys.exit(1)
+
+@click.command()
+@click.option('--username', help='User to grant permissions', required=True)
+@click.option('--template-name', help='Template to grant permissions for',
+              required=True)
+@click.option('--permission', type=click.Choice(['read', 'execute', 'admin']),
+              help='Type of permission', default='read')
+def cli_template_permissions(username, template_name, permission):
+    """
+    This sets the template permissions for a user
+    """
+    try:
+        config = Config(config_file())
+        guard = Guard(config)
+        role_id = guard.get_role_id(template_name, permission)
+        user_id = guard.get_user_id(username)
+        guard.user_role(user_id, role_id)
+        print('User {0} successfully granted {1} permissions for template {2}'.format(username, permission, template_name))
+    except GuardError as error:
+        print("Execution Error: {0}".format(error))
+        sys.exit(1)

--- a/lib/tc.py
+++ b/lib/tc.py
@@ -236,7 +236,7 @@ class Guard(object):
         """
         api = self.api
         try:
-            result = api.update_user_role(user_id, role_id)
+            api.update_user_role(user_id, role_id)
         except APIError as error:
             raise GuardError(error)
 

--- a/lib/tc.py
+++ b/lib/tc.py
@@ -38,7 +38,7 @@ class Guard(object):
             template_name (str): the name of template
 
         Retruns:
-            (str): template id if found
+            (int): template id if found
 
         Raises:
             GuardError
@@ -46,6 +46,55 @@ class Guard(object):
         api = self.api
         try:
             data = api.template_data(template_name)
+            return data['results'][0]['id']
+        except APIError as error:
+            raise GuardError(error)
+
+    def get_role_id(self, template_name, permission):
+        """
+        Returns a role id from a template permission combination
+        Args:
+            template_id (int): the id of the template
+            permission (str): permission for the role
+
+        Retruns:
+            (int): role id if found
+
+        Raises:
+            GuardError
+        """
+        api = self.api
+        try:
+            data = api.role_data()
+            # now iterate through all roles and search for the right combination of template id and permission
+            for role in data['results']:
+                role_type = role['name'].lower()
+                resource_type = role['summary_fields'].get('resource_type')
+                resource_name = role['summary_fields'].get('resource_name')
+                if ((resource_type) and
+                    (resource_name) and
+                    (role_type.lower() == permission.lower()) and
+                    (resource_type.lower() == 'job template') and
+                    (resource_name.lower() == template_name.lower())):
+                    return role['id']
+        except APIError as error:
+            raise GuardError(error)
+
+    def get_user_id(self, username):
+        """
+        Returns a user id from a username
+        Args:
+            username (str): the name of the user
+
+        Retruns:
+            (int): user id if found
+
+        Raises:
+            GuardError
+        """
+        api = self.api
+        try:
+            data = api.user_data(username)
             return data['results'][0]['id']
         except APIError as error:
             raise GuardError(error)
@@ -166,6 +215,23 @@ class Guard(object):
         except APIError as error:
             raise GuardError(error)
 
+    def user_role(self, user_id, role_id):
+        """
+        Adds a role to a user in ansible tower
+
+        Args:
+            user_id (int): id of the user which should be granted permissions
+            role_id (int): id of the role to set for this user
+
+        Returns:
+            job_id (int): id of the triggered job
+        """
+        api = self.api
+        try:
+            result = api.update_user_role(user_id, role_id)
+        except APIError as error:
+            raise GuardError(error)
+
     def ad_hoc(self, ad_hoc):
         """
         Starts a ad hoc job in ansible tower
@@ -173,7 +239,6 @@ class Guard(object):
             ad_hoc (AdHoc): Inventory to run on
         Returns:
             job_id (int): id of the triggered job
-
         """
         api = self.api
         try:

--- a/lib/tc.py
+++ b/lib/tc.py
@@ -77,6 +77,11 @@ class Guard(object):
                     (resource_type.lower() == 'job template') and
                     (resource_name.lower() == template_name.lower())):
                     return role['id']
+            # if we are here, we didnt find any suitable role
+            msg = "No role found for template '{0}' ".format(template_name)
+            msg = "{0}with permissions {1}. ".format(msg, permission)
+            msg = "{0}Please make sure that a suitable role exists".format(msg)
+            raise GuardError(msg)
         except APIError as error:
             raise GuardError(error)
 
@@ -95,6 +100,9 @@ class Guard(object):
         api = self.api
         try:
             data = api.user_data(username)
+            if data['count'] == 0:
+                msg = "No user '{0}' found".format(username)
+                raise GuardError(msg)
             return data['results'][0]['id']
         except APIError as error:
             raise GuardError(error)

--- a/lib/tc.py
+++ b/lib/tc.py
@@ -104,6 +104,8 @@ class Guard(object):
                 msg = "No user '{0}' found".format(username)
                 raise GuardError(msg)
             return data['results'][0]['id']
+        except APIError as error:
+            raise GuardError(error)
 
     def get_project_id(self, project_name):
         """

--- a/lib/tc.py
+++ b/lib/tc.py
@@ -236,7 +236,7 @@ class Guard(object):
         """
         api = self.api
         try:
-            api.update_user_role(user_id, role_id)
+            return api.update_user_role(user_id, role_id)
         except APIError as error:
             raise GuardError(error)
 

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ setup(
             'kick=lib.cli:cli_kick',
             'ad_hoc_and_monitor=lib.cli:cli_ad_hoc_and_monitor',
             'ad_hoc=lib.cli:cli_ad_hoc',
-            'template_permissions=lib.cli:cli_template_permissions'
+            'template_permissions=lib.cli:cli_template_permissions',
             'update_project=lib.cli:cli_update_project'
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,7 @@ setup(
             'kick=lib.cli:cli_kick',
             'ad_hoc_and_monitor=lib.cli:cli_ad_hoc_and_monitor',
             'ad_hoc=lib.cli:cli_ad_hoc',
+            'template_permissions=lib.cli:cli_template_permissions'
         ],
     },
     tests_require=['tox'],

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -242,7 +242,6 @@ def test_update_user_role(monkeypatch):
         mock = MockRequest()
         mock.text = fake_text
         mock.status_code = 204
-        mock.status_code = 200
         return mock
 
     def mockerror(*args, **kwargs):
@@ -261,6 +260,8 @@ def test_update_project_id(monkeypatch):
     def mockreturn(*args, **kwargs):
         mock = MockRequest()
         mock.text = fake_text
+        mock.status_code = 200
+        mock.reason = "This failed"
         return mock
 
     def mockerror(*args, **kwargs):

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -238,6 +238,31 @@ def test_launch_template_id(monkeypatch):
         api.launch_template_id(template_id='', extra_vars='')
 
 
+def test_update_user_role(monkeypatch):
+    expected_id = 23
+    fake_text = json.dumps({'results': [{'id': expected_id}]})
+
+    def mockreturn(*args, **kwargs):
+        mock = MockRequest()
+        mock.text = fake_text
+        mock.status_code = 204
+        return mock
+
+    def mockerror(*args, **kwargs):
+        raise APIError
+
+    api = basic_api()
+    monkeypatch.setattr('requests.post', mockreturn)
+    result = api.update_user_role(user_id='23', role_id=['42',])
+    assert result.status_code == 204
+
+    # result = api.update_user_role(template_id='', extra_vars='')
+    # assert result == json.loads(fake_text)
+    #
+    # monkeypatch.setattr('requests.post', mockerror)
+    # with pytest.raises(APIError):
+    #     api.update_user_role(template_id='', extra_vars='')
+
 def test_launch_data_to_url():
     api = basic_api()
     url = '123'
@@ -336,6 +361,8 @@ def test_get_data(monkeypatch):
 
     monkeypatch.setattr('requests.get', mockreturn)
     assert api.template_data(name='') == json.loads(fake_text)
+    assert api.role_data() == json.loads(fake_text)
+    assert api.user_data(username='') == json.loads(fake_text)
     assert api.inventory_data(name='') == json.loads(fake_text)
     assert api.credentials_data(name='') == json.loads(fake_text)
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -7,6 +7,7 @@ from click.testing import CliRunner
 from lib.tc import GuardError
 from lib.cli import cli_kick, cli_monitor, DEFAULT_CONFIGURATION, config_file
 from lib.cli import cli_kick_and_monitor, cli_ad_hoc_and_monitor, cli_ad_hoc
+from lib.cli import cli_template_permissions
 from lib.cli import extra_var_to_dict, CLIError
 
 
@@ -193,4 +194,38 @@ def test_cli_ad_hoc(monkeypatch):
     monkeypatch.setattr('lib.tc.Guard.ad_hoc', mockerror)
     monkeypatch.setattr('lib.api.APIv1.launch_ad_hoc', mockerror)
     result = runner.invoke(cli_ad_hoc, args)
+    assert result.exit_code == 1
+
+def test_cli_template_permissions(monkeypatch):
+
+    def mockerror(*args, **kwargs):
+        raise GuardError
+
+    def mockreturn(*args, **kwargs):
+        return {'results': [], 'url': 'test', 'id': 'test'}
+
+    def mock_user_id(*args, **kwargs):
+        return '23'
+
+    def mock_role_id(*args, **kwargs):
+        return '42'
+
+
+    monkeypatch.setattr('lib.tc.Guard.user_role', mockreturn)
+    monkeypatch.setattr('lib.tc.Guard.get_user_id', mock_user_id)
+    monkeypatch.setattr('lib.tc.Guard.get_role_id', mock_role_id)
+    monkeypatch.setattr('lib.cli.config_file', mock_config_file)
+
+    runner = CliRunner()
+    args = ['--username', 'hans',
+            '--template-name', 'wurst',
+            '--permission', 'admin']
+    # clean execution
+    result = runner.invoke(cli_template_permissions, args)
+    assert result.exit_code == 0
+
+    # error!
+    monkeypatch.setattr('lib.tc.Guard.user_role', mockerror)
+    monkeypatch.setattr('lib.api.APIv1.update_user_role', mockerror)
+    result = runner.invoke(cli_template_permissions, args)
     assert result.exit_code == 1

--- a/test/test_guard.py
+++ b/test/test_guard.py
@@ -40,17 +40,6 @@ def basic_guard():
     return Guard(config)
 
 
-class ApiMock(object):
-    def __init__(self):
-        pass
-
-    def template_name(self):
-        return BASIC_JSON_DATA['id']
-
-    def get_template_id(self):
-        return json.load(BASIC_JSON_DATA)
-
-
 class MockRequest(object):
     def __init__(self, *args, **kwargs):
         self.status_code = None
@@ -83,6 +72,57 @@ def test_get_template_id(monkeypatch):
     with pytest.raises(GuardError):
         guard.get_template_id(template_name='')
 
+def test_get_user_id(monkeypatch):
+    guard = basic_guard()
+
+    expected_id = '1'
+    fake_result = {'results': [{'id': expected_id}], 'count': '1'}
+    def mockreturn(self, username):
+        return fake_result
+    monkeypatch.setattr('lib.api.APIv1.user_data', mockreturn)
+    assert guard.get_user_id('') == expected_id
+
+    def mockreturn(self, username):
+        raise APIError
+    monkeypatch.setattr('lib.api.APIv1.user_data', mockreturn)
+    with pytest.raises(GuardError):
+        guard.get_user_id(username='')
+
+    fake_result = {'results': [], 'count': 0}
+    def mockreturn(self, username):
+        return fake_result
+    monkeypatch.setattr('lib.api.APIv1.user_data', mockreturn)
+    with pytest.raises(GuardError):
+        guard.get_user_id(username='')
+
+def test_get_role_id(monkeypatch):
+    guard = basic_guard()
+
+    expected_id = '1'
+    permission = 'Admin'
+    resource_type = 'job template'
+    resource_name = 'CoolerJOb'
+    fake_result = {'results':
+                    [{'id': expected_id,
+                      'name': permission,
+                      'summary_fields':
+                        {'resource_type': resource_type,
+                          'resource_name': resource_name}
+                        }
+                    ]}
+    def mockreturn(self):
+        return fake_result
+    monkeypatch.setattr('lib.api.APIv1.role_data', mockreturn)
+    assert guard.get_role_id(resource_name, permission) == expected_id
+
+    with pytest.raises(GuardError):
+        guard.get_role_id(resource_name, 'GibtsNicht')
+
+    def mockreturn(self):
+        raise APIError
+    monkeypatch.setattr('lib.api.APIv1.role_data', mockreturn)
+    with pytest.raises(GuardError):
+        guard.get_role_id(resource_name, '')
 
 def test_kick(monkeypatch):
     # quite a lot of changes, this test has to be updated
@@ -90,10 +130,10 @@ def test_kick(monkeypatch):
     expected_value = 'kick'
 
     def mockreturn(*args, **kwargs):
-        expected_value
+        return expected_value
 
     monkeypatch.setattr('lib.api.APIv1.launch_template_id', mockreturn)
-    guard.kick(template_id='', extra_vars='')
+    assert guard.kick(template_id='', extra_vars='') == expected_value
 
     def mockreturn(*args, **kwargs):
         raise APIError
@@ -101,6 +141,23 @@ def test_kick(monkeypatch):
     monkeypatch.setattr('lib.api.APIv1.launch_template_id', mockreturn)
     with pytest.raises(GuardError):
         guard.kick(template_id='', extra_vars='')
+
+def test_user_role(monkeypatch):
+    # quite a lot of changes, this test has to be updated
+    guard = basic_guard()
+    expected_value = 'user_role'
+
+    def mockreturn(*args, **kwargs):
+        return expected_value
+
+    monkeypatch.setattr('lib.api.APIv1.update_user_role', mockreturn)
+    assert guard.user_role(user_id='', role_id='') == expected_value
+
+    def mockreturn(*args, **kwargs):
+        raise APIError
+    monkeypatch.setattr('lib.api.APIv1.update_user_role', mockreturn)
+    with pytest.raises(GuardError):
+        guard.user_role(user_id='', role_id='')
 
 
 def test_download_url():


### PR DESCRIPTION
This is implemented and can be used like that:

```
    Usage: template_permissions [OPTIONS]

      This sets the template permissions for a user

    Options:
      --username TEXT                 User to grant permissions  [required]
      --template-name TEXT            Template to grant permissions for
                                      [required]
      --permission [read|execute|admin]
                                      Type of permission
      --help                          Show this message and exit.
```
